### PR TITLE
linux-raspberrypi_4.19: fix SRCREV

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_4.19.bb
+++ b/recipes-kernel/linux/linux-raspberrypi_4.19.bb
@@ -3,7 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/linux-raspberrypi:"
 LINUX_VERSION ?= "4.19.27"
 LINUX_RPI_BRANCH ?= "rpi-4.19.y"
 
-SRCREV = "c0e09b3420442df016ee7906985535d644481e4b"
+SRCREV = "707de567bc638b8b5457dec675f5cc59e50f862f"
 SRC_URI = " \
     git://github.com/raspberrypi/linux.git;protocol=git;branch=${LINUX_RPI_BRANCH} \
     "


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->
Looks like commit "c0e09b3420442df016ee7906985535d644481e4b" in rpi-4.19.y branch got rebased as "707de567bc638b8b5457dec675f5cc59e50f862f". So, changing it to fix "unable to find revision" error.
