### PR TITLE
meta-raspberrypi: Whitelisting components and plugins which are

### DIFF
--- a/conf/machine/raspberrypi3.conf
+++ b/conf/machine/raspberrypi3.conf
@@ -13,6 +13,13 @@ MACHINE_EXTRA_RRECOMMENDS += "\
     bluez-firmware-rpidistro-bcm4345c0-hcd \
 "
 
+LICENSE_FLAGS_WHITELIST = "commercial_gstreamer1.0-libav \
+                           commercial_gstreamer1.0-omx \
+                           commercial_faad2 \
+                           commercial_libomxil"
+
+MACHINE_FEATURES += "vc4graphics"
+
 SDIMG_KERNELIMAGE ?= "kernel7.img"
 UBOOT_MACHINE = "rpi_3_32b_config"
 SERIAL_CONSOLES ?= "115200;ttyS0"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,1 +1,5 @@
 PACKAGECONFIG_append_rpi = " hls libmms faad"
+
+EXTRA_OECONF += " --enable-debugutils"
+
+FILES_${PN} += "${libdir}/gstreamer-*/*.so"


### PR DESCRIPTION
having ristricted license "commercial".And enabling vc4graphics.

gstreamer1.0-plugins-bad : Enabling debug utils and packaging getreamer
plugins.

Signed-off-by: Riyaz <Riyaz.l@ltts.com>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
